### PR TITLE
Deploy to Clojars without GPG signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Recide
+# Recide [![Clojars Project](https://img.shields.io/clojars/v/com.workiva/recide.svg)](https://clojars.org/com.workiva/recide)
 
 *recide, third-person singular present indicative of `recidere`:* - to fall back, come to naught; to curtail
 

--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,10 @@
                  [org.clojure/data.fressian "0.2.1"]
                  [com.workiva/utiliva "0.1.0"]]
 
+  :deploy-repositories {"clojars"
+                        {:url "https://repo.clojars.org"
+                         :sign-releases false}}
+
   :source-paths ["src"]
   :test-paths ["test"]
   :java-source-paths ["java-src"]


### PR DESCRIPTION
## Description of Changes

  - Previous Artifacts have been deployed to Clojars without GPG signing, this overrides the default `lein deploy clojars` profile to not use GPG signing

## Proposed Testing Steps (If Applicable)

  -

## Relevant Issues (If Applicable)

  -
